### PR TITLE
Action for initial ContactBone creation

### DIFF
--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionController.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionController.cs
@@ -211,6 +211,11 @@ namespace Leap.Unity.Interaction {
     /// </summary>
     public Action OnGraspEnd = () => { };
 
+    /// <summary>
+    /// Called when contact data is initialized.
+    /// </summary>
+    public Action<InteractionController> OnContactInitialized = (interactionController) => { };
+
     #endregion
 
     #region Unity Events
@@ -957,6 +962,7 @@ namespace Leap.Unity.Interaction {
         if (initContact()) {
           finishInitContact();
           _contactInitialized = true;
+          OnContactInitialized?.Invoke(this);
         }
         else {
           return;


### PR DESCRIPTION
finishInitContact() finishes the contact bone setup and then sets the bool _contactInitialized to be true. 
However, both of these private. In addition, the property _wasContactInitialized which encapsulates _contactInitialized is protected. 
Thus, there is no way to know when the contact bones were initialized.